### PR TITLE
Fix installation docs

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -44,7 +44,7 @@ Installing the datastore
 
    git clone https://github.com/dalmatinerdb/dalmatinerdb.git
    cd dalmatinerdb
-   make deps all rel
+   make all rel
    cp -r rel/dalmatinerdb $TARGET_DIRECTORY
    cd $TARGET_DIRECTORY
    cp etc/dalmatinerdb.conf.example etc/dalmatinerdb.conf

--- a/installation.rst
+++ b/installation.rst
@@ -33,7 +33,7 @@ From Source
 
 Dependencies:
 
-* Erlang > R16B3
+* Erlang > R16B3 < R19
 * Make
 * GCC
 * G++

--- a/installation.rst
+++ b/installation.rst
@@ -36,6 +36,7 @@ Dependencies:
 * Erlang > R16B3
 * Make
 * GCC
+* G++
 
 Installing the datastore
 ````````````````````````


### PR DESCRIPTION
Trying to build dalmatinerdb I found a couple of problems with the installation docs.
- g++ is required
- make deps is not a valid target
- building on erlang 19 fails
